### PR TITLE
Add concept of game state services and sockets

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./genericTypes";
 
-export * from "./services/health";
 export * from "./services/games";
+export * from "./services/gameState";
+export * from "./services/health";
 
 export * from "./availableServices";

--- a/packages/api/src/services/gameState/gameStateService.ts
+++ b/packages/api/src/services/gameState/gameStateService.ts
@@ -1,0 +1,67 @@
+import { Service, ServiceDefinition } from "../../genericTypes/service";
+import { GameId, GameType, PlayerId, GameState } from "./gameStateTypes";
+
+export interface GetGameState {
+  gameId: GameId;
+  gameType: GameType;
+  playerId: PlayerId; // TODO: should be in the header
+}
+
+export interface CreateGame {
+  gameConfiguration: object;
+  gameName: string;
+  gameType: GameType;
+  playerId: PlayerId; // TODO: should be in the header
+  version: string;
+}
+
+export interface UpdateGame {
+  gameId: GameId;
+  newGameState: Partial<object>;
+  playerId: PlayerId; // TODO: should be in the header
+  timestamp: string;
+  version: string;
+}
+
+export type AvailableGame = Pick<
+  GameState,
+  "gameId" | "gameType" | "players"
+>[];
+
+export interface AvailableGames {
+  games: AvailableGame;
+}
+
+export interface UpdateGameResponse {
+  didAcceptChange: boolean;
+  newGameState: GameState;
+}
+
+export interface GameStateApi extends Service {
+  createGame: {
+    payload: CreateGame;
+    response: GameState;
+  };
+  getAvailableGames: {
+    payload: Record<string, never>;
+    response: AvailableGames;
+  };
+  getGameState: {
+    payload: GetGameState;
+    response: GameState;
+  };
+  updateGame: {
+    payload: UpdateGame;
+    response: UpdateGameResponse;
+  };
+}
+
+export const GameStateServiceDefinition: ServiceDefinition<GameStateApi> = {
+  controller: "game-state",
+  endpoints: {
+    createGame: "create-game",
+    getAvailableGames: "get-available-games",
+    getGameState: "get-game-state",
+    updateGame: "update-game"
+  }
+};

--- a/packages/api/src/services/gameState/gameStateSocket.ts
+++ b/packages/api/src/services/gameState/gameStateSocket.ts
@@ -1,0 +1,43 @@
+import { HandleMessage, SocketDefinition } from "../../genericTypes";
+import { GameId, GameState, PlayerId } from "./gameStateTypes";
+
+export interface IdentifyPlayerSocket {
+  gameId: GameId;
+  playerId: PlayerId;
+  socketId: string;
+}
+
+export interface GameStateFromClientToServer extends HandleMessage {
+  identify: IdentifyPlayerSocket;
+}
+
+export interface GameStateFromServerToClient extends HandleMessage {
+  identify: IdentifyPlayerSocket;
+  updateGameState: GameState;
+}
+
+export const GameStateClientSocketDefinition: SocketDefinition<
+  GameStateFromClientToServer,
+  GameStateFromServerToClient
+> = {
+  receiveMessage: {
+    identify: "identify",
+    updateGameState: "updateGameState"
+  },
+  sendMessage: {
+    identify: "identify"
+  }
+};
+
+export const GameStateServerSocketDefinition: SocketDefinition<
+  GameStateFromServerToClient,
+  GameStateFromClientToServer
+> = {
+  receiveMessage: {
+    identify: "identify"
+  },
+  sendMessage: {
+    identify: "identify",
+    updateGameState: "updateGameState"
+  }
+};

--- a/packages/api/src/services/gameState/gameStateTypes.ts
+++ b/packages/api/src/services/gameState/gameStateTypes.ts
@@ -1,0 +1,17 @@
+export type GameId = string & { __brand: "game-id" };
+export type GameType = string & { __brand: "game-type" };
+export type PlayerId = string & { __brand: "player-id" };
+
+export type CurrentGameState = "waiting" | "playing" | "finished";
+
+export interface GameState {
+  currentGameState: CurrentGameState;
+  gameConfiguration: object;
+  gameId: GameId;
+  gameState: object;
+  gameType: GameType;
+  players: {
+    [player: PlayerId]: Record<string, never>;
+  };
+  version: string;
+}

--- a/packages/api/src/services/gameState/index.ts
+++ b/packages/api/src/services/gameState/index.ts
@@ -1,0 +1,3 @@
+export * from "./gameStateService";
+export * from "./gameStateSocket";
+export * from "./gameStateTypes";


### PR DESCRIPTION
Adds new concepts for game state management with the intent to deprecate the "tileGame" and "tileSocket" folders. This does not yet wire up the concepts to the DB or BE.