### PR TITLE
Make pong two player

### DIFF
--- a/packages/games/src/backend/pong/pong.ts
+++ b/packages/games/src/backend/pong/pong.ts
@@ -8,11 +8,16 @@ export interface PongGameState extends WithTimestamp {
     x: number;
     y: number;
   };
-  paddle: {
+  leftPaddle: {
     x: number;
     y: number;
   };
-  score: number;
+  leftScore: number;
+  rightPaddle: {
+    x: number;
+    y: number;
+  };
+  rightScore: number;
 }
 
 export interface PongGameConfiguration {}
@@ -32,11 +37,16 @@ export class PongGameServer
           y: 290
         },
         lastUpdatedAt: new Date().toISOString(),
-        paddle: {
-          x: 350,
-          y: 550
+        leftPaddle: {
+          x: 50,
+          y: 400
         },
-        score: 0
+        leftScore: 0,
+        rightPaddle: {
+          x: 730,
+          y: 400
+        },
+        rightScore: 0
       },
       version: createGameRequest.version
     };


### PR DESCRIPTION
This pull request includes significant updates to the Pong game to support two-player functionality. The changes involve modifications to the game state, server, and frontend to handle two paddles and two scores. The most important changes include updating the game state structure, modifying the server initialization, and updating the frontend to handle two paddles and scores.

### Game State Updates:
* Changed `PongGameState` to include `leftPaddle`, `rightPaddle`, `leftScore`, and `rightScore` instead of a single paddle and score.

### Server Initialization:
* Updated `PongGameServer` to initialize positions and scores for both left and right paddles.

### Frontend Updates:
* Updated `PongGameScene` to handle two paddles (`leftPaddle` and `rightPaddle`) and two scores (`leftScore` and `rightScore`). [[1]](diffhunk://#diff-617e8ea1ff33d1c9674993ca1c1079f2ffd31e28d75350ad4d303599cc450ffeL14-R19) [[2]](diffhunk://#diff-617e8ea1ff33d1c9674993ca1c1079f2ffd31e28d75350ad4d303599cc450ffeL26-R30)
* Added keyboard controls for both paddles: WASD for the left paddle and arrow keys for the right paddle.
* Enhanced collision detection to handle interactions with both paddles and updated scoring logic to reflect the two-player setup. [[1]](diffhunk://#diff-617e8ea1ff33d1c9674993ca1c1079f2ffd31e28d75350ad4d303599cc450ffeL82-R193) [[2]](diffhunk://#diff-617e8ea1ff33d1c9674993ca1c1079f2ffd31e28d75350ad4d303599cc450ffeL141-R224)