### PR TITLE
Configure celebration when a word is guessed

### DIFF
--- a/packages/games/src/frontend/fishbowl/components/globalScreen/RoundInProgress.tsx
+++ b/packages/games/src/frontend/fishbowl/components/globalScreen/RoundInProgress.tsx
@@ -3,6 +3,7 @@ import { DisplayText, Flex } from "@/lib/radix";
 import { useFishbowlSelector } from "../../store/fishbowlRedux";
 import { FishbowlTimer } from "../timer/FishbowlTimer";
 import styles from "./RoundInProgress.module.scss";
+import { WordCelebration } from "./components/WordCelebration";
 import { useAdvancePlayer } from "./hooks/useAdvancePlayer";
 
 export const RoundInProgress = () => {
@@ -11,12 +12,14 @@ export const RoundInProgress = () => {
   const activeRound = useFishbowlSelector(
     (s) => s.gameStateSlice.gameState?.round
   );
+
   if (activeRound === undefined) {
     return;
   }
 
   return (
     <Flex align="center" flex="1" gap="9" justify="center">
+      <WordCelebration />
       <Flex direction="column" gap="3">
         <Flex align="center" className={styles.activePlayer} gap="5" p="5">
           <PlayerIcon

--- a/packages/games/src/frontend/fishbowl/components/globalScreen/components/WordCelebration.tsx
+++ b/packages/games/src/frontend/fishbowl/components/globalScreen/components/WordCelebration.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+import Confetti from "react-confetti";
+import { useFishbowlSelector } from "../../../store/fishbowlRedux";
+
+export const WordCelebration = () => {
+  const [showConfetti, setShowConfetti] = useState(false);
+
+  const activeRound = useFishbowlSelector(
+    (s) => s.gameStateSlice.gameState?.round
+  );
+
+  useEffect(() => {
+    if (activeRound == null || activeRound.correctGuesses.length === 0) {
+      return;
+    }
+
+    // Show confetti when a new correct guess is made
+    setShowConfetti(true);
+    const timer = setTimeout(() => setShowConfetti(false), 500);
+    return () => clearTimeout(timer);
+  }, [activeRound?.correctGuesses.length]);
+
+  const sharedConfettiProps = {
+    confettiSource: {
+      h: 100,
+      w: 100,
+      y: window.innerHeight
+    },
+    friction: 0.85,
+    gravity: 1.2,
+    initialVelocityY: 200,
+    numberOfPieces: 200,
+    recycle: showConfetti,
+    tweenDuration: 700
+  };
+
+  return (
+    <>
+      <Confetti
+        {...sharedConfettiProps}
+        confettiSource={{
+          ...sharedConfettiProps.confettiSource,
+          x: 0
+        }}
+        initialVelocityX={150}
+      />
+      <Confetti
+        {...sharedConfettiProps}
+        confettiSource={{
+          ...sharedConfettiProps.confettiSource,
+          x: window.innerWidth
+        }}
+        initialVelocityX={-150}
+      />
+    </>
+  );
+};


### PR DESCRIPTION
This pull request introduces a new feature to celebrate correct guesses during the "Round in Progress" phase of the Fishbowl game. The main changes include adding a `WordCelebration` component that displays confetti animations and integrating this component into the `RoundInProgress` screen.

### New Feature: Word Celebration for Correct Guesses

* **Added `WordCelebration` Component**: A new component, `WordCelebration`, was created to display confetti animations when a player makes a correct guess. It uses the `react-confetti` library and listens for changes in the number of correct guesses in the active round. The confetti animation is triggered for 1.5 seconds each time a new correct guess is detected. (`packages/games/src/frontend/fishbowl/components/globalScreen/components/WordCelebration.tsx`)

* **Integrated `WordCelebration` into `RoundInProgress`**: The `WordCelebration` component was imported and added to the `RoundInProgress` screen, ensuring that the confetti animation is displayed during the active round. (`packages/games/src/frontend/fishbowl/components/globalScreen/RoundInProgress.tsx`) [[1]](diffhunk://#diff-5999690626d64c4fac20f59d15141f3e9e02f67b0a93eb94166ab31781e835edR6) [[2]](diffhunk://#diff-5999690626d64c4fac20f59d15141f3e9e02f67b0a93eb94166ab31781e835edR15-R22)