### PR TITLE
Flush out UI for final score

### DIFF
--- a/packages/games/src/frontend/fishbowl/DisplayFishbowl.tsx
+++ b/packages/games/src/frontend/fishbowl/DisplayFishbowl.tsx
@@ -1,10 +1,10 @@
 import { Flex } from "@/lib/radix";
-import { useFishbowlSelector } from "./store/fishbowlRedux";
-import { ContributeWords } from "./playerComponents/components/ContributeWords";
-import { currentPhaseSelector } from "./store/sharedSelectors";
 import { ActivePlayer } from "./playerComponents/components/activePlayer/ActivePlayer";
+import { ContributeWords } from "./playerComponents/components/ContributeWords";
 import { GuessingPlayer } from "./playerComponents/components/guessingPlayer/GuessingPlayer";
 import { PlayerFinalScore } from "./playerComponents/components/PlayerFinalScore";
+import { useFishbowlSelector } from "./store/fishbowlRedux";
+import { currentPhaseSelector } from "./store/sharedSelectors";
 
 export const DisplayFishbowl = () => {
   const phase = useFishbowlSelector(currentPhaseSelector);

--- a/packages/games/src/frontend/fishbowl/globalScreen/components/FinalScore.module.scss
+++ b/packages/games/src/frontend/fishbowl/globalScreen/components/FinalScore.module.scss
@@ -1,0 +1,5 @@
+@use "@/styles/variables.scss" as vars;
+
+.scoreBox {
+    border-radius: 10px;
+}

--- a/packages/games/src/frontend/fishbowl/globalScreen/components/FinalScore.tsx
+++ b/packages/games/src/frontend/fishbowl/globalScreen/components/FinalScore.tsx
@@ -1,6 +1,11 @@
-import { Flex } from "@/lib/radix";
+import { DisplayText, Flex } from "@/lib/radix";
 import { useFishbowlSelector } from "../../store/fishbowlRedux";
 import { finalScoreSelector } from "../../store/sharedSelectors";
+import { PlayerIcon } from "@/components/player/PlayerIcon";
+import { getTeamColor } from "@/lib/stableIdentifiers/teamIdentifier";
+import styles from "./FinalScore.module.scss";
+import { motion } from "motion/react";
+import Confetti from "react-confetti";
 
 export const FinalScore = () => {
   const maybeFinalScores = useFishbowlSelector(finalScoreSelector);
@@ -9,5 +14,55 @@ export const FinalScore = () => {
     return <Flex>Final scores not available yet.</Flex>;
   }
 
-  return <Flex>{JSON.stringify(maybeFinalScores, null, 2)}</Flex>;
+  const totalTeams = Object.keys(maybeFinalScores.teamEntries).length;
+
+  return (
+    <Flex align="center" direction="column" flex="1" justify="center">
+      <Confetti
+        gravity={0.025}
+        height={window.innerHeight}
+        initialVelocityY={15}
+        style={{ zIndex: 0 }}
+        width={window.innerWidth}
+      />
+      <Flex direction="column" gap="9">
+        {maybeFinalScores.teamEntries.map((team, index) => (
+          <motion.div
+            animate={{ opacity: 1, y: 0 }}
+            initial={{ opacity: 0, y: 100 }}
+            key={index}
+            layout="position"
+            transition={{ delay: (totalTeams - index) * 1 }}
+          >
+            <Flex
+              className={styles.scoreBox}
+              direction="column"
+              flex="1"
+              gap="5"
+              p="8"
+              style={{ background: getTeamColor(team.players[0]?.team ?? 0) }}
+            >
+              <Flex align="center" flex="1" gap="5" justify="between" pb="4">
+                <Flex gap="5">
+                  {index === 0 && <DisplayText size="9">👑</DisplayText>}
+                  <DisplayText size="9">{team.teamName}</DisplayText>
+                </Flex>
+                <DisplayText ml="5" size="9">
+                  {team.totalScore}
+                </DisplayText>
+              </Flex>
+              <Flex gap="2" wrap="wrap">
+                {team.players.map((player) => (
+                  <Flex align="center" gap="2" key={player.playerId}>
+                    <PlayerIcon dimension={30} player={player} />
+                    <DisplayText size="7">{player.displayName}</DisplayText>
+                  </Flex>
+                ))}
+              </Flex>
+            </Flex>
+          </motion.div>
+        ))}
+      </Flex>
+    </Flex>
+  );
 };

--- a/packages/games/src/frontend/fishbowl/playerComponents/components/PlayerFinalScore.module.scss
+++ b/packages/games/src/frontend/fishbowl/playerComponents/components/PlayerFinalScore.module.scss
@@ -1,0 +1,5 @@
+@use "@/styles/variables.scss" as vars;
+
+.scoreBox {
+    border-radius: 10px;
+}

--- a/packages/games/src/frontend/fishbowl/playerComponents/components/PlayerFinalScore.tsx
+++ b/packages/games/src/frontend/fishbowl/playerComponents/components/PlayerFinalScore.tsx
@@ -1,6 +1,10 @@
-import { Flex } from "../../../../../lib/radix";
+import { DisplayText, Flex } from "@/lib/radix";
 import { useFishbowlSelector } from "../../store/fishbowlRedux";
 import { finalScoreSelector } from "../../store/sharedSelectors";
+import { PlayerIcon } from "@/components/player/PlayerIcon";
+import { getTeamColor } from "@/lib/stableIdentifiers/teamIdentifier";
+import styles from "./PlayerFinalScore.module.scss";
+import { motion } from "motion/react";
 
 export const PlayerFinalScore = () => {
   const maybeFinalScores = useFishbowlSelector(finalScoreSelector);
@@ -9,5 +13,49 @@ export const PlayerFinalScore = () => {
     return <Flex>Final scores not available yet.</Flex>;
   }
 
-  return <Flex>{JSON.stringify(maybeFinalScores, null, 2)}</Flex>;
+  const totalTeams = Object.keys(maybeFinalScores.teamEntries).length;
+
+  return (
+    <Flex align="center" direction="column" flex="1" justify="center">
+      <Flex direction="column" gap="5">
+        {maybeFinalScores.teamEntries.map((team, index) => (
+          <motion.div
+            animate={{ opacity: 1, y: 0 }}
+            initial={{ opacity: 0, y: 100 }}
+            key={team.teamName ?? index}
+            layout="position"
+            transition={{ delay: (totalTeams - index) * 1 }}
+          >
+            <Flex
+              className={styles.scoreBox}
+              direction="column"
+              flex="1"
+              gap="3"
+              key={index}
+              p="4"
+              style={{ background: getTeamColor(team.players[0]?.team ?? 0) }}
+            >
+              <Flex align="center" flex="1" gap="5" justify="between" pb="4">
+                <Flex gap="3">
+                  {index === 0 && <DisplayText size="7">👑</DisplayText>}
+                  <DisplayText size="7">{team.teamName}</DisplayText>
+                </Flex>
+                <DisplayText ml="5" size="7">
+                  {team.totalScore}
+                </DisplayText>
+              </Flex>
+              <Flex gap="2" wrap="wrap">
+                {team.players.map((player) => (
+                  <Flex align="center" gap="2" key={player.playerId}>
+                    <PlayerIcon dimension={25} player={player} />
+                    <DisplayText size="5">{player.displayName}</DisplayText>
+                  </Flex>
+                ))}
+              </Flex>
+            </Flex>
+          </motion.div>
+        ))}
+      </Flex>
+    </Flex>
+  );
 };


### PR DESCRIPTION
This pull request enhances the final score display for the Fishbowl game by introducing animations, styling improvements, and a more detailed layout for both the global screen and individual player views. It also includes minor import order adjustments for consistency.

### Final score display enhancements:
* [`packages/games/src/frontend/fishbowl/globalScreen/components/FinalScore.tsx`](diffhunk://#diff-a90bc76d4615398f2ea309f71c11f61183ffe878498737c05872ffc624c0923cL12-R67): Added confetti animations and improved the layout to display team scores with styled score boxes, team colors, and player details.
* [`packages/games/src/frontend/fishbowl/playerComponents/components/PlayerFinalScore.tsx`](diffhunk://#diff-74e78d8c328b53decdb3bae46b8cf965982edeb249fa7c66ada8967f5fff4f09L12-R60): Enhanced the player-specific score view with animations, styled score boxes, team colors, and player details.

### Styling improvements:
* [`packages/games/src/frontend/fishbowl/globalScreen/components/FinalScore.module.scss`](diffhunk://#diff-3b8146351e7c2e7ef5ceb9d5d080714367016bcfc9ad1765ba37a578d6cf6043R1-R5): Introduced a `scoreBox` class with rounded corners for better visual appeal.
* [`packages/games/src/frontend/fishbowl/playerComponents/components/PlayerFinalScore.module.scss`](diffhunk://#diff-3b8146351e7c2e7ef5ceb9d5d080714367016bcfc9ad1765ba37a578d6cf6043R1-R5): Added a similar `scoreBox` class for consistent styling across components.

### Code organization:
* [`packages/games/src/frontend/fishbowl/DisplayFishbowl.tsx`](diffhunk://#diff-1d2f21ae444893d44b467b4bcd4f575e507110452d6d07232be805ac03dac3d4L2-R7): Reordered imports for better readability and consistency.