### PR TITLE
Update the set player icon so its less in the way

### DIFF
--- a/packages/frontend/src/components/player/PlayerContext.module.scss
+++ b/packages/frontend/src/components/player/PlayerContext.module.scss
@@ -2,7 +2,7 @@
 
 .playerContainer {
     position: fixed;
-    bottom: 10px;
-    left: 10px;
+    bottom: 5px;
+    left: 0;
     z-index: 10;
 }

--- a/packages/frontend/src/components/player/SetPlayer.module.scss
+++ b/packages/frontend/src/components/player/SetPlayer.module.scss
@@ -1,12 +1,9 @@
 @use "@/styles/variables.scss" as vars;
 
 .trigger {
-    border: 1px solid vars.$black;
     cursor: pointer;
-    border-radius: 3px;
-    background: vars.$white;
 
     &:hover {
-        background: rgba(vars.$muted-font, 0.25);
+        opacity: 0.8;
     }
 }

--- a/packages/frontend/src/components/player/SetPlayer.tsx
+++ b/packages/frontend/src/components/player/SetPlayer.tsx
@@ -125,8 +125,7 @@ export const SetPlayer = ({
 
     return (
       <Flex align="center" className={styles.trigger} gap="2" px="3" py="1">
-        <PlayerIcon dimension={25} player={existingPlayer} />
-        <DisplayText>{existingPlayer.displayName}</DisplayText>
+        <PlayerIcon dimension={35} player={existingPlayer} />
       </Flex>
     );
   };


### PR DESCRIPTION
This pull request makes several updates to the player-related components in the frontend, focusing on styling adjustments and minor UI improvements. The changes include modifying CSS properties for better alignment and appearance, as well as updating the player icon's size in the `SetPlayer` component.

### Styling adjustments:
* [`packages/frontend/src/components/player/PlayerContext.module.scss`](diffhunk://#diff-51ff5d56928b3056b883959ca0b94e5686382fb07ad1f7a99e25d43436da5781L5-R6): Adjusted the `playerContainer` position to move it slightly closer to the bottom-left corner and ensure better alignment (`bottom: 5px; left: 0;`).
* [`packages/frontend/src/components/player/SetPlayer.module.scss`](diffhunk://#diff-ec324ae21e625218a52faed3dfccf29c619eef07569ca9e20b9bf04cd59fd837L4-R7): Removed the border, border-radius, and background color from the `.trigger` class and replaced the hover background effect with an opacity change for a cleaner look (`opacity: 0.8;`).

### UI improvements:
* [`packages/frontend/src/components/player/SetPlayer.tsx`](diffhunk://#diff-02add6b74c217f8538b2257c6da16a57908eea7bb48515f8b91e93c4975db6a4L128-R128): Increased the size of the `PlayerIcon` from 25px to 35px for better visibility and removed the `DisplayText` element to simplify the component layout.